### PR TITLE
代码高亮组件更新

### DIFF
--- a/lovue/src/components/CodeHighLight/index.vue
+++ b/lovue/src/components/CodeHighLight/index.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <pre><code :class="'language-'+lang" v-text="code">
+  <div v-show="code">
+    <pre><code :class="codeClass" v-text="code">
       </code></pre>
   </div>
 </template>
@@ -8,9 +8,17 @@
 import Prism from "prismjs";
 export default {
   name: "CodeHighLight",
-  props: ["code", "lang"],
+  props: {
+    code: { type: String, required: true },
+    lang: { type: String, default: "javascript" }
+  },
   data() {
     return {};
+  },
+  computed:{
+    codeClass:function(){
+      return 'language-'+this.lang
+    }
   },
   mounted() {
     Prism.highlightAll();

--- a/lovue/src/views/vueInstance.vue
+++ b/lovue/src/views/vueInstance.vue
@@ -19,7 +19,6 @@
       <p>代码块组件JS代码示例</p>
       <CodeHighLight
         :code='code.block1'
-        lang='javascript'
       ></CodeHighLight>
       <p>代码块组件html代码示例</p>
       <CodeHighLight


### PR DESCRIPTION
1. 考虑展示代码主要为JS类型，代码高亮组件lang属性默认设置为javascript，不加该属性则默认展示JS代码风格；
2.增加组件属性验证，code属性必填且为String类型，lang属性限定为字符串类型，否则浏览器控制台打印警告